### PR TITLE
Refactor context handling for server and client environments

### DIFF
--- a/api/edge/context.mjs
+++ b/api/edge/context.mjs
@@ -13,6 +13,8 @@ import {
 } from '../../src/utils.mjs';
 import importmap from '../../importmap.json';
 
+globalThis.litSsrCallConnectedCallback = true;
+
 const headers = {'content-type': 'text/html'};
 
 const head = () => render(html`

--- a/api/serverless/context.mjs
+++ b/api/serverless/context.mjs
@@ -13,6 +13,8 @@ import {
 } from '##/src/utils.mjs';
 import importmap from '##/src/importmap.mjs';
 
+globalThis.litSsrCallConnectedCallback = true;
+
 const head = () => render(html`
   <script src='/src/page-context.mjs' type='module' defer></script>
   <script src='/src/server-url.mjs' type='module' defer></script>

--- a/src/page-context.mjs
+++ b/src/page-context.mjs
@@ -1,4 +1,4 @@
-import {LitElement, html} from 'lit';
+import {html, isServer, LitElement} from 'lit';
 import {ContextProvider, createContext} from '@lit/context';
 
 export const context = createContext(Symbol('page'));
@@ -7,15 +7,11 @@ export class PageContext extends LitElement {
 
   static properties = {page: {state: true}};
 
-  _page = new ContextProvider(this, {context});
-
-  serverCallback() {
-    super.serverCallback();
-    this._page.setValue(this.page);
-  }
+  _page = new ContextProvider(isServer ? globalThis.litServerRoot : document.body, {context});
 
   connectedCallback() {
     super.connectedCallback();
+    if (isServer) return this._page.setValue(this.page);
     const {href: url} = location;
     this._page.setValue(this.page = {url});
   }

--- a/src/server-url.mjs
+++ b/src/server-url.mjs
@@ -16,9 +16,11 @@ export class ServerURL extends LitElement {
   _page = new ContextConsumer(this, {context, subscribe: true});
 
   render() {
+    const date = new Date();
     const url = this.url || this._page.value?.url;
     return html`
       <h1>Server URL</h1>
+      <time>${date}</time>
       <pre>${url}</pre>
     `;
   }

--- a/src/server-url.mjs
+++ b/src/server-url.mjs
@@ -25,6 +25,10 @@ export class ServerURL extends LitElement {
     `;
   }
 
+  firstUpdated(_changedProperties) {
+    this.requestUpdate();
+  }
+
 }
 
 customElements.define('server-url', ServerURL);


### PR DESCRIPTION
Updated `ContextProvider` initialization to properly handle server-side rendering using `isServer`. Introduced a global flag `litSsrCallConnectedCallback` to optimize SSR behavior while ensuring consistency between server and client contexts.